### PR TITLE
Caching fix: turn off caching on user login form

### DIFF
--- a/cwd_saml_mapping.module
+++ b/cwd_saml_mapping.module
@@ -220,7 +220,8 @@ function cwd_saml_mapping_preprocess_item_list(&$variables) {
 function cwd_saml_mapping_form_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
   if ($form_id == 'user_login_form') {
     $config = \Drupal::config('cwd_saml_mapping.config_form');
-
+    $form['#cache'] = ['max-age' => 0];
+    
     $hide_drupal_login_prod = $config->getRawData()['hide_drupal_login_prod'] ?? false;
     $is_prod_and_hide = (isset($_ENV['PANTHEON_ENVIRONMENT']) && $_ENV['PANTHEON_ENVIRONMENT'] === 'live' && $hide_drupal_login_prod);
     $hide_drupal_login = $config->getRawData()['hide_drupal_login'] ?? false;


### PR DESCRIPTION
This fixes the issue of anonymous users going to a log in page with a redirect that is previously cached by another thus sending them to the wrong page after log in